### PR TITLE
Minor fixes

### DIFF
--- a/Editor/DevPanel.cs
+++ b/Editor/DevPanel.cs
@@ -101,14 +101,14 @@ namespace Filta {
                 }
             }
 
-            EditorGUILayout.LabelField("Create Vertex Component");
+            EditorGUILayout.LabelField("Create Vertex Trackers");
             EditorGUILayout.BeginHorizontal();
             _vertexNumber = EditorGUILayout.IntField("Vertex Index", _vertexNumber);
             if (GUILayout.Button("Create")) {
-                if (_simulator.vertexComponents == null) {
-                    _simulator.vertexComponents = new List<Simulator.VertexComponent>();
+                if (_simulator.vertexTrackers == null) {
+                    _simulator.vertexTrackers = new List<Simulator.VertexTracker>();
                 }
-                GameObject newVertex = _simulator.GenerateVertexComponent(_vertexNumber);
+                GameObject newVertex = _simulator.GenerateVertexTracker(_vertexNumber);
                 Selection.activeGameObject = newVertex;
             }
             EditorGUILayout.EndHorizontal();

--- a/Editor/DevPanel.cs
+++ b/Editor/DevPanel.cs
@@ -93,11 +93,11 @@ namespace Filta {
             EditorGUILayout.LabelField("Simulator", EditorStyles.boldLabel);
             if (_simulator.isPlaying) {
                 if (GUILayout.Button("Stop")) {
-                    _simulator.isPlaying = false;
+                    _simulator.PauseSimulator();
                 }
             } else {
                 if (GUILayout.Button("Play")) {
-                    _simulator.isPlaying = true;
+                    _simulator.ResumeSimulator();
                 }
             }
 

--- a/Editor/DevPanel.cs
+++ b/Editor/DevPanel.cs
@@ -109,7 +109,11 @@ namespace Filta {
                     _simulator.vertexTrackers = new List<Simulator.VertexTracker>();
                 }
                 GameObject newVertex = _simulator.GenerateVertexTracker(_vertexNumber);
+                //To select the newly created vertex tracker so that the user would be aware it has been selected.
                 Selection.activeGameObject = newVertex;
+                _vertexNumber = 0;
+                //takes away keyboard control from the input field (for the vertex number) so it actually shows the reset vertex number
+                EditorGUI.FocusTextInControl(null);
             }
             EditorGUILayout.EndHorizontal();
             _simulator.showVertexNumbers = EditorGUILayout.Toggle("Show Vertex Index", _simulator.showVertexNumbers);

--- a/Editor/DevPanel.cs
+++ b/Editor/DevPanel.cs
@@ -275,13 +275,9 @@ namespace Filta {
         private string sceneName;
         void CreateNewScene() {
             sceneName = (string)EditorGUILayout.TextField("Filter scene filename:", sceneName);
+            GUI.enabled = !String.IsNullOrWhiteSpace(sceneName);
             if (GUILayout.Button("Create new filter scene file")) {
                 bool success;
-                if (string.IsNullOrEmpty(sceneName)) {
-                    SetStatusMessage("Filter filename cannot be empty", true);
-                    Debug.LogError("Filter filename cannot be empty");
-                    return;
-                }
                 success = AssetDatabase.CopyAsset("Packages/com.getfilta.artist-unityplug/Core/templateScene.unity", $"Assets/Filters/{sceneName}.unity");
                 //success = AssetDatabase.CopyAsset("Assets/Core/templateScene.unity", $"Assets/Filters/{sceneName}.unity");
                 if (!success) {
@@ -295,6 +291,8 @@ namespace Filta {
                     EditorSceneManager.OpenScene($"Assets/Filters/{sceneName}.unity", OpenSceneMode.Single);
                 }
             }
+
+            GUI.enabled = true;
             FindSimulator(PlayModeStateChange.EnteredEditMode);
 
         }

--- a/Editor/DevPanel.cs
+++ b/Editor/DevPanel.cs
@@ -108,7 +108,8 @@ namespace Filta {
                 if (_simulator.vertexComponents == null) {
                     _simulator.vertexComponents = new List<Simulator.VertexComponent>();
                 }
-                _simulator.GenerateVertexComponent(_vertexNumber);
+                GameObject newVertex = _simulator.GenerateVertexComponent(_vertexNumber);
+                Selection.activeGameObject = newVertex;
             }
             EditorGUILayout.EndHorizontal();
             _simulator.showVertexNumbers = EditorGUILayout.Toggle("Show Vertex Index", _simulator.showVertexNumbers);

--- a/Simulator/Simulator.cs
+++ b/Simulator/Simulator.cs
@@ -457,10 +457,11 @@ public class Simulator : MonoBehaviour {
         }
     }
 
-    public void GenerateVertexComponent(int index) {
+    public GameObject GenerateVertexComponent(int index) {
         GameObject vertex = new GameObject();
         VertexComponent vertexComponent = new VertexComponent { vertexIndex = index, holder = vertex };
         vertexComponents.Add(vertexComponent);
+        return vertex;
     }
 
 

--- a/Simulator/Simulator.cs
+++ b/Simulator/Simulator.cs
@@ -184,7 +184,7 @@ public class Simulator : MonoBehaviour {
             return;
         }
 
-        long time = (long)(DateTime.Now - _startTime).TotalMilliseconds;
+        long time = (long)(DateTime.Now - _startTime).TotalMilliseconds + _pauseTime;
         Playback(time);
     }
 
@@ -275,6 +275,16 @@ public class Simulator : MonoBehaviour {
         HandleVertexPairing();
     }
 
+    public long _pauseTime;
+    public void PauseSimulator(){
+        _pauseTime = (long)(DateTime.Now - _startTime).TotalMilliseconds + _pauseTime;
+        isPlaying = false;
+    }
+
+    public void ResumeSimulator(){
+        isPlaying = true;
+    }
+
     private void Playback(long currentTime) {
         if (_recordingLength <= 0) {
             return;
@@ -282,6 +292,7 @@ public class Simulator : MonoBehaviour {
 
         if (currentTime > _recordingLength) {
             Replay();
+            _pauseTime = 0;
             return;
         }
 
@@ -591,11 +602,11 @@ public class Simulator : MonoBehaviour {
             Simulator sim = (Simulator)target;
             if (sim.isPlaying) {
                 if (GUILayout.Button("Stop")) {
-                    sim.isPlaying = false;
+                    sim.PauseSimulator();
                 }
             } else {
                 if (GUILayout.Button("Play")) {
-                    sim.isPlaying = true;
+                    sim.ResumeSimulator();
                 }
             }
 

--- a/Simulator/Simulator.cs
+++ b/Simulator/Simulator.cs
@@ -272,6 +272,7 @@ public class Simulator : MonoBehaviour {
         _filterObject.position = Vector3.zero;
         _filterObject.rotation = Quaternion.identity;
         _filterObject.localScale = Vector3.one;
+        HandleVertexPairing();
     }
 
     private void Playback(long currentTime) {
@@ -318,7 +319,6 @@ public class Simulator : MonoBehaviour {
             _faceMeshVisualiser.transform.position -= _faceMeshVisualiser.transform.forward * _visualiserOffset;
             SetMeshTopology();
             PositionTrackers(faceData);
-            HandleVertexPairing();
             FaceData prevFaceData = _faceRecording.faceDatas[i - 1];
             UpdateMasks(faceData, prevFaceData, currentTime);
 
@@ -461,6 +461,7 @@ public class Simulator : MonoBehaviour {
         GameObject vertex = new GameObject();
         VertexComponent vertexComponent = new VertexComponent { vertexIndex = index, holder = vertex };
         vertexComponents.Add(vertexComponent);
+        HandleVertexPairing();
         return vertex;
     }
 

--- a/Simulator/Simulator.cs
+++ b/Simulator/Simulator.cs
@@ -435,32 +435,32 @@ public class Simulator : MonoBehaviour {
     #region Vertex Pairing
 
     [NonSerialized]
-    public List<VertexComponent> vertexComponents;
+    public List<VertexTracker> vertexTrackers;
 
     private void HandleVertexPairing() {
-        if (vertexComponents == null) {
+        if (vertexTrackers == null) {
             return;
         }
-        for (int i = 0; i < vertexComponents.Count; i++) {
-            VertexComponent vertexComponent = vertexComponents[i];
-            if (vertexComponent.holder == null) {
-                vertexComponents.Remove(vertexComponent);
-                // if a vertexComponent is removed, we break out of the loop to avoid throwing an exception.
+        for (int i = 0; i < vertexTrackers.Count; i++) {
+            VertexTracker vertexTracker = vertexTrackers[i];
+            if (vertexTracker.holder == null) {
+                vertexTrackers.Remove(vertexTracker);
+                // if a vertexTracker is removed, we break out of the loop to avoid throwing an exception.
                 // since this loop runs every frame, there is no negative impact.
                 break;
             }
-            vertexComponent.holder.transform.SetParent(_vertices);
-            vertexComponent.holder.name = $"VertexComponentIndex_{vertexComponent.vertexIndex}";
-            if (vertexComponent.vertexIndex < _faceMesh.vertices.Count) {
-                vertexComponent.holder.transform.localPosition = _faceMesh.vertices[vertexComponent.vertexIndex];
+            vertexTracker.holder.transform.SetParent(_vertices);
+            vertexTracker.holder.name = $"VertexTrackerIndex_{vertexTracker.vertexIndex}";
+            if (vertexTracker.vertexIndex < _faceMesh.vertices.Count) {
+                vertexTracker.holder.transform.localPosition = _faceMesh.vertices[vertexTracker.vertexIndex];
             }
         }
     }
 
-    public GameObject GenerateVertexComponent(int index) {
+    public GameObject GenerateVertexTracker(int index) {
         GameObject vertex = new GameObject();
-        VertexComponent vertexComponent = new VertexComponent { vertexIndex = index, holder = vertex };
-        vertexComponents.Add(vertexComponent);
+        VertexTracker vertexTracker = new VertexTracker { vertexIndex = index, holder = vertex };
+        vertexTrackers.Add(vertexTracker);
         HandleVertexPairing();
         return vertex;
     }
@@ -470,7 +470,7 @@ public class Simulator : MonoBehaviour {
 
     #region Class/Struct Definition
 
-    public class VertexComponent {
+    public class VertexTracker {
         public int vertexIndex;
         public GameObject holder;
     }


### PR DESCRIPTION
this PR contains the following fixes:

- make status bar red for errors and white for normal info
- make create new filter button inactive when the user hasn't put anything in the scene name field
- auto focus on new vertexTracker when a user generates a new one
- fix issue of vertexTrackers not enforcing naming structure when simulator is not playing
- rename vertexComponent to vertexTrackers
- clear vertex number field when user creates
- resume simulator from where the user stops it.