### PR TITLE
If package not found, load from assets plugin

### DIFF
--- a/Editor/DevPanel.cs
+++ b/Editor/DevPanel.cs
@@ -36,6 +36,7 @@ namespace Filta {
         private string selectedArtKey = "";
         private Vector2 leftScrollPosition;
         private Vector2 rightScrollPosition;
+        private string assetPrefix = "Packages/com.getfilta.artist-unityplug";
 
         private Dictionary<string, ArtMeta> privateCollection = new Dictionary<string, ArtMeta>();
         private static LoginResponse loginData;
@@ -57,6 +58,9 @@ namespace Filta {
         private int _vertexNumber;
 
         private async void OnEnable() {
+            assetPrefix = AssetDatabase.IsValidFolder("Packages/com.getfilta.artist-unityplug") 
+                ? "Packages/com.getfilta.artist-unityplug"
+                : "Assets/artist-unityplug"; 
             EditorApplication.playModeStateChanged += FindSimulator;
             FindSimulator(PlayModeStateChange.EnteredEditMode);
             _pluginInfo = new PluginInfo { version = 1 };
@@ -290,8 +294,7 @@ namespace Filta {
                 if (!AssetDatabase.IsValidFolder("Assets/Filters")){
                     AssetDatabase.CreateFolder("Assets", "Filters");
                 }
-                
-                success = AssetDatabase.CopyAsset("Packages/com.getfilta.artist-unityplug/Core/templateScene.unity", $"Assets/Filters/{sceneName}.unity");
+                success = AssetDatabase.CopyAsset($"{assetPrefix}/Core/templateScene.unity", $"Assets/Filters/{sceneName}.unity");
                 //success = AssetDatabase.CopyAsset("Assets/Core/templateScene.unity", $"Assets/Filters/{sceneName}.unity");
                 if (!success) {
                     SetStatusMessage("Failed to create new filter scene file", true);

--- a/Simulator/Simulator.cs
+++ b/Simulator/Simulator.cs
@@ -89,6 +89,12 @@ public class Simulator : MonoBehaviour {
 #if UNITY_EDITOR
     private void OnEnable() {
         _filePath = Path.GetFullPath("Packages/com.getfilta.artist-unityplug");
+        bool packagePluginExists = AssetDatabase.IsValidFolder("Packages/com.getfilta.artist-unityplug");
+        bool assetPluginExists = AssetDatabase.IsValidFolder("Assets/artist-unityplug");
+        if (!packagePluginExists && assetPluginExists) {
+            _filePath = Path.GetFullPath("Assets/artist-unityplug");
+        }
+        
         //_filePath = Application.dataPath;
         EditorApplication.hierarchyChanged += GetSkinnedMeshRenderers;
         EditorApplication.hierarchyChanged += GetFaceMeshFilters;
@@ -215,7 +221,9 @@ public class Simulator : MonoBehaviour {
         string[] textureFiles =
             Directory.GetFiles($"{_filePath}/Simulator/Recordings", "*.png", SearchOption.AllDirectories);
         foreach (string textFile in textureFiles) {
-            string prefix = _filePath == Application.dataPath ? "Assets" : "Packages/com.getfilta.artist-unityplug";
+            string prefix = AssetDatabase.IsValidFolder("Assets/artist-unityplug") 
+                ? "Assets/artist-unityplug" 
+                : "Packages/com.getfilta.artist-unityplug";
             string assetPath = prefix + textFile.Replace(_filePath, "").Replace('\\', '/');
             Texture sourceText = (Texture)AssetDatabase.LoadAssetAtPath(assetPath, typeof(Texture));
             _frames.Add(sourceText);


### PR DESCRIPTION
The problem is that in order to get Unity Editor to not freak out about a million duplicate guids between Packages/com.getfilta.artist-unityplug and the cloned artist-unityplug repo, or to just "Fix them" by flipping all my *.meta guids (which then breaks the project), I had to remove com.getfilta.artist-unityplug from Packages/manifest.json. 

This causes a different class of problems : assets loaded from the package now need to be correctly loaded from the cloned repo.

The fix is to check whether the package is installed and/or whether the plugin is living under assets, and to use the appropriate location for loading resources.

This got me to the initial stage. Not sure if more changes are required elsewhere.