### PR TITLE
Make so upload failures (and other failures) are handled correctly

### DIFF
--- a/Editor/DevPanel.cs
+++ b/Editor/DevPanel.cs
@@ -619,6 +619,18 @@ namespace Filta {
                     return;
                 }
             }
+            if (_bundles.ContainsKey(parsed.artid)) {
+                //Only allows uploading of filter if a version is NOT currently being bundled or if it is in Limbo
+                //Limbo is when the filter has been successfully uploaded to cloud storage, but something has stopped it from being processed by assetbundler
+                var bundle = _bundles[parsed.artid];
+                // or if it has been in the "uploading" state for more than 5 minutes 
+                bool isTooLongUploading = bundle.bundleQueuePosition == Uploading && GetTimeSince(bundle.lastUpdated) > TimeSpan.FromMinutes(5);
+                Debug.Log($"isTooLongUploading:{isTooLongUploading}");
+                if (bundle.bundleQueuePosition != Limbo && !isTooLongUploading) {
+                    SetStatusMessage("Error: Previous upload still being processed. Please wait a few minutes and try again.", true);
+                    return;
+                }
+            }
             using UnityWebRequest upload = UnityWebRequest.Put(parsed.url, bytes);
             await upload.SendWebRequest();
             await GetPrivateCollection();

--- a/Editor/DevPanel.cs
+++ b/Editor/DevPanel.cs
@@ -301,7 +301,7 @@ namespace Filta {
         private Dictionary<string, Bundle> _bundles = new Dictionary<string, Bundle>();
 
         private EventSourceReader _evt;
-        private async void GetFiltersOnQueue() {
+        private void GetFiltersOnQueue() {
             ListenToQueue();
         }
 

--- a/Editor/DevPanel.cs
+++ b/Editor/DevPanel.cs
@@ -298,44 +298,20 @@ namespace Filta {
         #endregion
 
         #region Bundle Queue
-
         private Dictionary<string, Bundle> _bundles = new Dictionary<string, Bundle>();
+
         private EventSourceReader _evt;
         private async void GetFiltersOnQueue() {
-            _bundles = new Dictionary<string, Bundle>();
-            string getUrlQueue = $"{RTDB_URLBASE}/bundle_queue.json?orderBy=\"artistId\"&equalTo=\"{loginData.localId}\"&print=pretty";
-            using UnityWebRequest request = UnityWebRequest.Get(getUrlQueue);
-            await request.SendWebRequest();
-            JObject results = JObject.Parse(request.downloadHandler.text);
-            foreach (JProperty prop in results.Properties()) {
-                string id = prop.Name;
-                string bundleTitle = prop.Value["title"].Value<string>();
-                int queue = prop.Value["queue"].Value<int>();
-                _bundles.Add(id, new Bundle { queue = queue, title = bundleTitle });
-            }
             ListenToQueue();
         }
 
         private void ListenToQueue() {
             _evt = new EventSourceReader(new Uri($"{RTDB_URLBASE}/bundle_queue.json?orderBy=\"artistId\"&equalTo=\"{loginData.localId}\"")).Start();
             _evt.MessageReceived += (sender, e) => {
-                if (e.Event == "put") {
-                    try {
-                        QueueResponse response = JsonConvert.DeserializeObject<QueueResponse>(e.Message);
-                        string[] paths = response.path.Split('/');
-                        if (response.data is int queue) {
-                            _bundles[paths[1]].queue = queue;
-                        } else {
-                            SetStatusMessage($"{_bundles[paths[1]].title} successfully processed! (5/5)");
-                            _bundles.Remove(paths[1]);
-                        }
-
-                    } catch (Exception exception) {
-                        if (exception is JsonReaderException) {
-                            return;
-                        }
-                        Debug.LogError(exception.Message);
-                    }
+                if (e.Event != "keep-alive") {
+                    // if there was some update, then just refresh
+                    // the private collection.
+                    GetPrivateCollection();
                 }
             };
             _evt.Disconnected += async (sender, e) => {
@@ -362,12 +338,12 @@ namespace Filta {
             foreach (KeyValuePair<string, Bundle> bundle in _bundles) {
                 GUILayout.BeginHorizontal();
                 GUILayout.Label(bundle.Value.title);
-                if (bundle.Value.queue == Uploading) {
+                if (bundle.Value.bundleQueuePosition == Uploading) {
                     GUILayout.Label("still uploading");
-                } else if (bundle.Value.queue == Limbo) {
+                } else if (bundle.Value.bundleQueuePosition == Limbo) {
                     GUILayout.Label("in Limbo");
                 } else {
-                    GUILayout.Label(bundle.Value.queue.ToString());
+                    GUILayout.Label(bundle.Value.bundleQueuePosition.ToString());
                 }
                 GUILayout.EndHorizontal();
             }
@@ -383,7 +359,9 @@ namespace Filta {
 
         public class Bundle {
             public string title;
-            public int queue;
+            public int bundleQueuePosition;
+            public string bundleStatus;
+            public Int64 lastUpdated;
         }
 
         public class QueueResponse {
@@ -641,13 +619,6 @@ namespace Filta {
                     return;
                 }
             }
-            //Only allows uploading of filter if a version is NOT currently being bundled or if it is in Limbo
-            //Limbo is when the filter has been successfully uploaded to cloud storage, but something has stopped it from being processed by assetbundler
-            if (_bundles.ContainsKey(parsed.artid) && _bundles[parsed.artid].queue != Limbo) {
-                SetStatusMessage("Error: Previous upload still being processed. Please wait a few minutes and try again.", true);
-                return;
-            }
-            _bundles.Add(parsed.artid, new Bundle { queue = Uploading, title = selectedArtTitle });
             using UnityWebRequest upload = UnityWebRequest.Put(parsed.url, bytes);
             await upload.SendWebRequest();
             await GetPrivateCollection();
@@ -878,6 +849,7 @@ namespace Filta {
         }
 
         private async Task GetPrivateCollection() {
+            Debug.Log("GetPrivateCollection");
             string url = $"https://firestore.googleapis.com/v1/projects/{(UseTestEnvironment ? "filta-dev" : "filta-machina")}/databases/(default)/documents/priv_collection/{loginData.localId}";
             using UnityWebRequest req = UnityWebRequest.Get(url);
             req.SetRequestHeader("authorization", $"Bearer {loginData.idToken}");
@@ -894,6 +866,7 @@ namespace Filta {
                 var jsonResult = JObject.Parse(req.downloadHandler.text);
                 var result = ParseArtMetas(jsonResult);
                 privateCollection = result;
+                _bundles = GetActiveBundles(privateCollection);
             } else {
                 SetStatusMessage("Error Deleting. Check console for details.", true);
                 Debug.LogError("Request Result: " + req.result);
@@ -931,12 +904,51 @@ namespace Filta {
                         case "preview":
                             value.preview = previewObject.Value<string>("stringValue");
                             break;
+                        case "bundleQueuePosition":
+                            value.bundleQueuePosition = previewObject.Value<int>("integerValue");
+                            break;
+                        case "bundleStatus":
+                            value.bundleStatus = previewObject.Value<string>("stringValue");
+                            break;
+                        case "lastUpdated":
+                            value.lastUpdated = previewObject.Value<Int64>("integerValue");
+                            break;
                     }
                 }
 
                 output.Add(name, value);
             }
             return output;
+        }
+
+        private Dictionary<string, Bundle> GetActiveBundles(Dictionary<string, ArtMeta> artMetas) {
+            var result = new Dictionary<string, Bundle>();
+            foreach (var artMeta in artMetas) {
+                if (artMeta.Value.bundleStatus == "need-package" ||
+                    artMeta.Value.bundleStatus == "package" ||
+                    artMeta.Value.bundleStatus == "bundling") {
+                    result.Add(artMeta.Key, new Bundle() {
+                        title = artMeta.Value.title,
+                        bundleQueuePosition = artMeta.Value.bundleQueuePosition,
+                        bundleStatus = artMeta.Value.bundleStatus,
+                        lastUpdated = artMeta.Value.lastUpdated
+                    });
+                } else if (artMeta.Value.bundleStatus == "bundled" && GetTimeSince(artMeta.Value.lastUpdated) < TimeSpan.FromSeconds(10)) {
+                    SetStatusMessage($"{artMeta.Value.title} successfully processed! (5/5)");
+                } else if (artMeta.Value.bundleStatus == "error-bundling" && GetTimeSince(artMeta.Value.lastUpdated) < TimeSpan.FromSeconds(10)) {
+                    SetStatusMessage($"{artMeta.Value.title} : error processing :(", true);
+                }
+            }
+            return result;
+        }
+
+
+        private TimeSpan GetTimeSince(Int64 jsonTimestamp) {
+            DateTime origin = new DateTime(1970, 1, 1, 0, 0, 0, 0);
+            DateTime timestamp = origin.AddMilliseconds(jsonTimestamp); // convert from milliseconds to seconds
+            var result = DateTime.UtcNow - timestamp;
+            Debug.Log($"DT.utcnow:{DateTime.UtcNow};jsonts:{jsonTimestamp},timestamp:{timestamp},delta:{result}");
+            return result;
         }
 
 

--- a/Util/Datatypes.cs
+++ b/Util/Datatypes.cs
@@ -2,8 +2,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 namespace Filta.Datatypes {
-    public class ArtMeta
-    {
+    public class ArtMeta {
         public string artId;
         public string artist;
         public string creationTime;
@@ -14,9 +13,11 @@ namespace Filta.Datatypes {
         public string thumbFilename;
         public Sprite Thumbnail;
         public bool isPublic;
+        public int bundleQueuePosition;
+        public string bundleStatus;
+        public long lastUpdated;
 
-        public override string ToString()
-        {
+        public override string ToString() {
             return $"artid:{artId} artist:{artist} creationTime:{creationTime} preview:{preview} publishtime:{publishTime} title:{title} description:{description}";
         }
     }


### PR DESCRIPTION
This change is much bigger than could be hoped for. Initially I strived mightily for a more surgical change to solve the problem, but ultimately found that I was stopped by:

1. Not enough information in the bundle queue (specifically no idea of how much time had passed since upload had begun)
2. Fragility in bundle_queue update parsing. Fragility includes specifically:
    - no handling of 'patch' so multi-field updates are ignored
    - assumption that anything other than the 'queue' field being updated represents a removal of an item from the queue
    - assumption that any field update was an update to the 'queue' field
    - In general a very "targeted" parsing which was not robust in the face of changes to bundle_queue structure.
 
And so ultimately I opted for a solution which would be robust and extensible with respect to future changes. Here's what I did:
- update functions and assetbundler to maintain bundleQueuePosition in the priv_collection entry (lastUpdated and bundleStatus were already present). They still write to the bundle_queue as before. 
- ensure that in all places that the bundle_queue is poked, we update priv_collection prior to that point.
- make so assetbundler cleans up bundleQueuePosition field when entry is removed.
- Make so in DevPanel when the RTDB query for userid gets pinged, all we do is refresh the GetPrivateCollection() data
- Make so in DevPanel when GetPrivateCollection(), we scan collection for items which are currently being bundled and put them in _bundles dictionary.
- As an opportunistic enhancement, report when assetbundling operations failed. Previously this was going unreported to the user.
- Make so in DevPanel, in the place where we initiate the assetbundling, we check before doing any work whether there is already a bundling in flight. But if the bundling is at the "still uploading" stage for more than 5 mins, let a new bundling operation proceed.

Obviously this is a big change. The primary downside of this change is that there is a lot more querying of the priv_collection than went on before. There are a couple of upsides. One is that we get robust, easier-to-maintain, information about the state of the user's inflight operations. Another is that we are a bit closer (not there yet) to phasing out use of the RTDB to maintain bundling UI.

After struggling with trying to tack on lastUpdated into the bundle_queue, and get the bundle_queue update parsing to work correctly, I really believe that this change is the way to go. 