### PR TITLE
Refactor DevPanel, switch to remote login

### DIFF
--- a/Editor/Authentication.cs
+++ b/Editor/Authentication.cs
@@ -1,0 +1,223 @@
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.Networking;
+using System;
+using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Linq;
+using EvtSource;
+using Newtonsoft.Json;
+using Filta.Datatypes;
+using Newtonsoft.Json.Linq;
+using UnityEditor.PackageManager.Requests;
+using UnityEditor.SceneManagement;
+using UnityEngine.SceneManagement;
+using Object = System.Object;
+
+namespace Filta {
+
+    public enum LoginResult {
+        Success,
+        Error,
+        NoRefreshToken,
+        ExpiredToken
+    }
+
+    public enum AuthenticationState {
+        LoggedOut,
+        LoggedIn,
+        PendingAsk,
+        PendingAskApproval,
+        LoggingIn,
+        PendingRefresh
+    }
+
+    public class Authentication {
+        public static Authentication Instance { get; private set; }
+        static Authentication() {
+            Instance = new Authentication();
+        }
+        private const string REFRESH_KEY = "RefreshToken";
+        private const string customTokenLoginURL = "https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=";
+        private const string refreshURL = "https://securetoken.googleapis.com/v1/token?key=";
+        private LoginResponse loginData;
+        private static DateTime _expiryTime;
+
+        public EventHandler AuthStateChanged = delegate { };
+        private AuthenticationState _authState = AuthenticationState.LoggedOut;
+        public AuthenticationState AuthState {
+            get { return _authState; }
+            private set {
+                if (_authState != value) {
+                    _authState = value;
+                    AuthStateChanged(this, EventArgs.Empty);
+                }
+            }
+        }
+
+        public bool IsLoggedIn {
+            get {
+                return AuthState == AuthenticationState.LoggedIn;
+            }
+        }
+
+        public string RemoteLoginPin { get; private set; }
+        public string RemoteLoginUrl { get; private set; }
+
+        public string LoginToken { get { return loginData.idToken; } }
+        public string Uid { get { return loginData.localId; } }
+
+        public bool IsLoginExpired { get { return _expiryTime > DateTime.Now; } }
+
+        public void LogOut(bool hardLogout = true) {
+            loginData = null;
+            // hardLogout means the user told us to log out, as 
+            // opposed to we just noticed the token expired, so refreshing
+            if (hardLogout) {
+                AuthState = AuthenticationState.LoggedOut;
+                PlayerPrefs.SetString(REFRESH_KEY, null);
+                PlayerPrefs.Save();
+            }
+        }
+
+        public async Task<LoginResult> LoginAutomatic() {
+            string token = PlayerPrefs.GetString(REFRESH_KEY, null);
+            if (String.IsNullOrEmpty(token)) {
+                return LoginResult.NoRefreshToken;
+            }
+
+            AuthState = AuthenticationState.PendingRefresh;
+            WWWForm postData = new();
+            postData.AddField("grant_type", "refresh_token");
+            postData.AddField("refresh_token", token);
+            using UnityWebRequest www = UnityWebRequest.Post(refreshURL + Global.FIREBASE_APIKEY, postData);
+            Global.FireStatusChange(this, "Logging you in...");
+            await www.SendWebRequest();
+            string response = www.downloadHandler.text;
+            if (response.Contains("TOKEN_EXPIRED")) {
+                AuthState = AuthenticationState.LoggedOut;
+                Global.FireStatusChange(this, "Error: Token has expired", true);
+                return LoginResult.ExpiredToken;
+            } else if (response.Contains("USER_NOT_FOUND")) {
+                AuthState = AuthenticationState.LoggedOut;
+                Global.FireStatusChange(this, "Error: User was not found", true);
+            } else if (response.Contains("INVALID_REFRESH_TOKEN")) {
+                AuthState = AuthenticationState.LoggedOut;
+                Global.FireStatusChange(this, "Error: Invalid token provided", true);
+            } else if (response.Contains("id_token")) {
+                RefreshResponse refreshData = JsonUtility.FromJson<RefreshResponse>(response);
+                loginData = new LoginResponse {
+                    refreshToken = refreshData.refresh_token,
+                    idToken = refreshData.id_token,
+                    expiresIn = refreshData.expires_in,
+                    localId = refreshData.user_id
+                };
+                Global.FireStatusChange(this, "Login successful!");
+                _expiryTime = DateTime.Now.AddSeconds(loginData.expiresIn);
+                PlayerPrefs.SetString(REFRESH_KEY, loginData.refreshToken);
+                PlayerPrefs.Save();
+                AuthState = AuthenticationState.LoggedIn;
+                return LoginResult.Success;
+            } else {
+                Debug.LogError(response);
+                Global.FireStatusChange(this, "Unknown Error. Check console for more information.", true);
+                return LoginResult.Error;
+            }
+            return LoginResult.Error;
+        }
+        public async Task<LoginResult> Login(bool stayLoggedIn) {
+            AuthState = AuthenticationState.PendingAsk;
+
+            try {
+                var response = await Backend.Instance.AskForRemoteLogin();
+                RemoteLoginPin = response.pin;
+                RemoteLoginUrl = response.url;
+                AuthState = AuthenticationState.PendingAskApproval;
+
+                // every two seconds, check if the user has approved the login
+                GetRemoteLoginAskStatusResponse statusResponse = null;
+                while (AuthState == AuthenticationState.PendingAskApproval) {
+                    await Task.Delay(2000);
+                    statusResponse = await Backend.Instance.GetRemoteLoginAskStatus(response.statusKey);
+                    if (statusResponse.status != "pending") {
+                        break;
+                    }
+                }
+                if (statusResponse != null && statusResponse.status == "granted") {
+                    AuthState = AuthenticationState.LoggingIn;
+                    Global.FireStatusChange(this, "Logging you in...");
+                    WWWForm postData = new();
+                    postData.AddField("token", statusResponse.token);
+                    postData.AddField("returnSecureToken", "true");
+                    using UnityWebRequest www = UnityWebRequest.Post(customTokenLoginURL + Global.FIREBASE_APIKEY, postData);
+                    await www.SendWebRequest();
+                    string signinResponse = www.downloadHandler.text;
+
+                    if (signinResponse.Contains("idToken")) {
+                        var signinData = JsonUtility.FromJson<LoginResponse>(signinResponse);
+                        // the problem at this point is that the response only includes a token, refresh token, 
+                        // and expiry. We need also the localId (user_id). So the first thing we do is a refresh. 
+                        // we don't expect this to fail.
+                        WWWForm refreshPostData = new();
+                        refreshPostData.AddField("grant_type", "refresh_token");
+                        refreshPostData.AddField("refresh_token", signinData.refreshToken);
+                        using UnityWebRequest refreshRequest = UnityWebRequest.Post(refreshURL + Global.FIREBASE_APIKEY, refreshPostData);
+                        Global.FireStatusChange(this, "Verifying login...");
+                        await refreshRequest.SendWebRequest();
+                        string refreshResponse = refreshRequest.downloadHandler.text;
+                        if (refreshResponse.Contains("id_token")) {
+                            RefreshResponse refreshData = JsonUtility.FromJson<RefreshResponse>(refreshResponse);
+                            loginData = new LoginResponse {
+                                refreshToken = refreshData.refresh_token,
+                                idToken = refreshData.id_token,
+                                expiresIn = refreshData.expires_in,
+                                localId = refreshData.user_id
+                            };
+                            _expiryTime = DateTime.Now.AddSeconds(loginData.expiresIn);
+                            if (stayLoggedIn) {
+                                PlayerPrefs.SetString(REFRESH_KEY, loginData.refreshToken);
+                                PlayerPrefs.Save();
+                            }
+                            AuthState = AuthenticationState.LoggedIn;
+                            return LoginResult.Success;
+                        } else {
+                            Debug.LogError(refreshResponse);
+                        }
+                    } else {
+                        // important as status message tells user to check console
+                        Debug.LogError(signinResponse);
+                    }
+                } else {
+                    // we could distinguish between denied and expired, but we don't
+                    Debug.LogError("Request expired.");
+                }
+            } catch (Exception e) {
+                Debug.LogError(e);
+            }
+            // if we got this far, we failed.
+            AuthState = AuthenticationState.LoggedOut;
+            Global.FireStatusChange(this, "Unknown Error. Check console for more information.", true);
+            return LoginResult.Error;
+
+        }
+    }
+    [Serializable]
+    public class LoginResponse {
+        public string localId;
+        public string displayName;
+        public string idToken;
+        public string refreshToken;
+        public int expiresIn;
+    }
+
+    [Serializable]
+    public class RefreshResponse {
+        public string id_token;
+        public string refresh_token;
+        public int expires_in;
+        public string user_id;
+    }
+
+}

--- a/Editor/Authentication.cs.meta
+++ b/Editor/Authentication.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 13dbd2bac68f041aaa602f7eeb35ea8b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Backend.cs
+++ b/Editor/Backend.cs
@@ -31,6 +31,8 @@ namespace Filta {
             set { EditorPrefs.SetBool(RunLocallySetting, value); }
         }
 
+
+        private string PRIV_COLLECTION_URL { get { return $"https://firestore.googleapis.com/v1/projects/{(Global.UseTestEnvironment ? "filta-dev" : "filta-machina")}/databases/(default)/documents/priv_collection/{Authentication.Instance.Uid}"; } }
         private string TEST_FUNC_LOCATION { get { return $"http://localhost:5001/{(Global.UseTestEnvironment ? "filta-dev" : "filta-machina")}/us-central1/"; } }
         private string FUNC_LOCATION { get { return Global.UseTestEnvironment ? "https://us-central1-filta-dev.cloudfunctions.net/" : "https://us-central1-filta-machina.cloudfunctions.net/"; } }
         private string RTDB_URLBASE { get { return Global.UseTestEnvironment ? "https://filta-dev-default-rtdb.firebaseio.com" : "https://filta-machina.firebaseio.com"; } }
@@ -130,8 +132,7 @@ namespace Filta {
 
 
         public async Task<ArtsAndBundleStatus> GetArtsAndBundleStatus() {
-            string url = $"https://firestore.googleapis.com/v1/projects/{(Global.UseTestEnvironment ? "filta-dev" : "filta-machina")}/databases/(default)/documents/priv_collection/{Authentication.Instance.Uid}";
-            using UnityWebRequest req = UnityWebRequest.Get(url);
+            using UnityWebRequest req = UnityWebRequest.Get(PRIV_COLLECTION_URL);
             req.SetRequestHeader("authorization", $"Bearer {Authentication.Instance.LoginToken}");
             await req.SendWebRequest();
             if (req.responseCode == 404) {

--- a/Editor/Backend.cs
+++ b/Editor/Backend.cs
@@ -1,0 +1,356 @@
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.Networking;
+using System;
+using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Linq;
+using EvtSource;
+using Newtonsoft.Json;
+using Filta.Datatypes;
+using Newtonsoft.Json.Linq;
+using UnityEditor.PackageManager.Requests;
+using UnityEditor.SceneManagement;
+using UnityEngine.SceneManagement;
+using Object = System.Object;
+
+namespace Filta {
+    public class Backend {
+
+        public static Backend Instance { get; private set; }
+        static Backend() {
+            Instance = new Backend();
+        }
+
+        public EventHandler BundleQueue = delegate { };
+        private const string RunLocallySetting = "Filta_RunLocally";
+        public bool RunLocally {
+            get { return EditorPrefs.GetBool(RunLocallySetting, false); }
+            set { EditorPrefs.SetBool(RunLocallySetting, value); }
+        }
+
+        private string TEST_FUNC_LOCATION { get { return $"http://localhost:5001/{(Global.UseTestEnvironment ? "filta-dev" : "filta-machina")}/us-central1/"; } }
+        private string FUNC_LOCATION { get { return Global.UseTestEnvironment ? "https://us-central1-filta-dev.cloudfunctions.net/" : "https://us-central1-filta-machina.cloudfunctions.net/"; } }
+        private string RTDB_URLBASE { get { return Global.UseTestEnvironment ? "https://filta-dev-default-rtdb.firebaseio.com" : "https://filta-machina.firebaseio.com"; } }
+        private string UPLOAD_URL { get { return RunLocally ? TEST_FUNC_LOCATION + "uploadArtSource" : FUNC_LOCATION + "uploadUnityPackage"; } }
+        private string DELETE_PRIV_ART_URL { get { return ConstructUrl("deletePrivArt"); } }
+        private string ConstructUrl(string functionName) {
+            return RunLocally ? TEST_FUNC_LOCATION + functionName : FUNC_LOCATION + functionName;
+        }
+        private const string releaseURL = "https://raw.githubusercontent.com/getfilta/artist-unityplug/main/releaseLogs.json";
+
+
+        private EventSourceReader _evt = null;
+
+        public void ListenToQueue() {
+            if (_evt == null) {
+                _evt = new EventSourceReader(new Uri($"{RTDB_URLBASE}/bundle_queue.json?orderBy=\"artistId\"&equalTo=\"{Authentication.Instance.Uid}\"")).Start();
+                _evt.MessageReceived += (sender, e) => {
+                    if (e.Event != "keep-alive") {
+                        BundleQueue(this, EventArgs.Empty);
+                    }
+                };
+                _evt.Disconnected += async (sender, e) => {
+                    await Task.Delay(e.ReconnectDelay);
+                    try {
+                        if (!_evt.IsDisposed) {
+                            _evt.Start(); // Reconnect to the same URL
+                        }
+                    } catch (Exception exception) {
+                        Debug.LogError(exception.Message);
+                    }
+
+                };
+            }
+        }
+        public void DisposeQueue() {
+            _evt?.Dispose();
+            _evt = null;
+        }
+
+        public async Task<string> Upload(string selectedArtKey, string selectedArtTitle, Hash128 hash, byte[] bytes) {
+            WWWForm postData = new();
+            if (selectedArtKey != "temp") {
+                Debug.LogWarning("Updating Art with artid: " + selectedArtKey);
+                postData.AddField("artid", selectedArtKey);
+            }
+            postData.AddField("uid", Authentication.Instance.LoginToken);
+            postData.AddField("hash", hash.ToString());
+            postData.AddField("title", selectedArtTitle);
+            using UnityWebRequest www = UnityWebRequest.Post(UPLOAD_URL, postData);
+            await www.SendWebRequest();
+            Global.FireStatusChange(this, "Connected! Uploading... (3/5)");
+            var response = www.downloadHandler.text;
+            UploadBundleResponse parsed;
+            if (!string.IsNullOrEmpty(www.error)) {
+                Global.FireStatusChange(this, $"Error Uploading: {www.error}");
+                Debug.LogError($"{response}:{www.error}");
+                return null;
+            } else {
+                try {
+                    parsed = JsonUtility.FromJson<UploadBundleResponse>(response);
+                } catch {
+                    Global.FireStatusChange(this, "Error! Check console for more information", true);
+                    Debug.LogError(response);
+                    return null;
+                }
+            }
+            using UnityWebRequest upload = UnityWebRequest.Put(parsed.url, bytes);
+            await upload.SendWebRequest();
+            return parsed.artid;
+        }
+
+        public async Task<string> DeletePrivateArt(string artId) {
+            WWWForm postData = new();
+            postData.AddField("uid", Authentication.Instance.LoginToken);
+            postData.AddField("artid", artId);
+            using UnityWebRequest www = UnityWebRequest.Post(DELETE_PRIV_ART_URL, postData);
+            await www.SendWebRequest();
+            var response = www.downloadHandler.text;
+            if (www.result == UnityWebRequest.Result.ProtocolError || www.result == UnityWebRequest.Result.ConnectionError) {
+                Debug.LogError(www.error + " " + www.downloadHandler.text);
+                return null;
+            } else {
+                return response;
+            }
+        }
+
+        public async Task<List<ReleaseInfo>> GetMasterReleaseInfo() {
+            try {
+                using UnityWebRequest req = UnityWebRequest.Get(releaseURL);
+                await req.SendWebRequest();
+                return JsonConvert.DeserializeObject<List<ReleaseInfo>>(req.downloadHandler.text);
+            } catch (Exception e) {
+                Debug.LogError(e.Message);
+                return new();
+            }
+        }
+
+
+        public async Task<ArtsAndBundleStatus> GetArtsAndBundleStatus() {
+            string url = $"https://firestore.googleapis.com/v1/projects/{(Global.UseTestEnvironment ? "filta-dev" : "filta-machina")}/databases/(default)/documents/priv_collection/{Authentication.Instance.Uid}";
+            using UnityWebRequest req = UnityWebRequest.Get(url);
+            req.SetRequestHeader("authorization", $"Bearer {Authentication.Instance.LoginToken}");
+            await req.SendWebRequest();
+            if (req.responseCode == 404) {
+                Debug.LogWarning("No uploads found. User could be new or service is down.");
+                Global.FireStatusChange(this, "No uploads found", true);
+                return new ArtsAndBundleStatus();
+            }
+            if (req.result == UnityWebRequest.Result.ConnectionError || req.result == UnityWebRequest.Result.ProtocolError) {
+                throw new Exception(req.error.ToString());
+            }
+            if (req.downloadHandler != null) {
+                var jsonResult = JObject.Parse(req.downloadHandler.text);
+                var result = new ArtsAndBundleStatus();
+                ParseArtMetas(jsonResult, result);
+                GetActiveBundles(result);
+                return result;
+            } else {
+                Global.FireStatusChange(this, "Error Deleting. Check console for details.", true);
+                Debug.LogError("Request Result: " + req.result);
+                return new ArtsAndBundleStatus();
+            }
+        }
+
+        private void ParseArtMetas(JObject json, ArtsAndBundleStatus collection) {
+            var fields = json["fields"];
+            if (fields == null) {
+                return;
+            }
+            if (fields.Type != JTokenType.Object) {
+                return;
+            }
+
+            foreach (var artMetaJson in fields.Children<JProperty>()) {
+                string name = artMetaJson.Name;
+                ArtMeta value = new() {
+                    artId = name
+                };
+                foreach (var field in artMetaJson.Value["mapValue"]["fields"].Children()) {
+                    var fieldName = field.Value<JProperty>().Name;
+                    var previewObject = field.Value<JProperty>().Value as JObject;
+                    switch (fieldName) {
+                        case "artist":
+                            value.artist = previewObject.Value<string>("stringValue");
+                            break;
+                        case "creationTime":
+                            value.creationTime = previewObject.Value<string>("integerValue");
+                            break;
+                        case "title":
+                            value.title = previewObject.Value<string>("stringValue");
+                            break;
+                        case "preview":
+                            value.preview = previewObject.Value<string>("stringValue");
+                            break;
+                        case "bundleQueuePosition":
+                            value.bundleQueuePosition = previewObject.Value<int>("integerValue");
+                            break;
+                        case "bundleStatus":
+                            value.bundleStatus = previewObject.Value<string>("stringValue");
+                            break;
+                        case "lastUpdated":
+                            value.lastUpdated = previewObject.Value<Int64>("integerValue");
+                            break;
+                    }
+                }
+
+                collection.ArtMetas.Add(name, value);
+            }
+        }
+
+        private void GetActiveBundles(ArtsAndBundleStatus collection) {
+            // analyze the artmetas with their bundle status and produce list of bundles, 
+            // plus any recent victories or defeats
+            collection.RecentStatusUpdate = ArtsAndBundleStatus.StatusUpdate.None;
+            foreach (var artMeta in collection.ArtMetas) {
+                if (artMeta.Value.bundleStatus == "need-package" ||
+                    artMeta.Value.bundleStatus == "package" ||
+                    artMeta.Value.bundleStatus == "bundling") {
+                    collection.Bundles.Add(artMeta.Key, new Bundle() {
+                        title = artMeta.Value.title,
+                        bundleQueuePosition = artMeta.Value.bundleQueuePosition,
+                        bundleStatus = artMeta.Value.bundleStatus,
+                        lastUpdated = artMeta.Value.lastUpdated
+                    });
+                } else if (artMeta.Value.bundleStatus == "bundled" && Global.GetTimeSince(artMeta.Value.lastUpdated) < TimeSpan.FromSeconds(10)) {
+                    Global.FireStatusChange(this, $"{artMeta.Value.title} successfully processed! (5/5)", false);
+                    collection.RecentStatusUpdate = ArtsAndBundleStatus.StatusUpdate.Success;
+                } else if (artMeta.Value.bundleStatus == "error-bundling" && Global.GetTimeSince(artMeta.Value.lastUpdated) < TimeSpan.FromSeconds(10)) {
+                    Global.FireStatusChange(this, $"{artMeta.Value.title} : error processing :(", true);
+                    collection.RecentStatusUpdate = ArtsAndBundleStatus.StatusUpdate.Error;
+                }
+            }
+        }
+
+        private async Task<TResponse> CallFunction<TRequest, TResponse>(string requestName, TRequest request, bool useAuth = false) {
+            var url = ConstructUrl(requestName);
+            var postData = $"{{\"data\":{JsonUtility.ToJson(request)}}}";
+            using UnityWebRequest req = new(url, "POST"); // UnityWebRequest.Post(url, postData);
+            byte[] jsonToSend = new System.Text.UTF8Encoding().GetBytes(postData);
+            req.uploadHandler = (UploadHandler)new UploadHandlerRaw(jsonToSend);
+            req.downloadHandler = (DownloadHandler)new DownloadHandlerBuffer();
+            req.SetRequestHeader("Content-Type", "application/json");
+            if (useAuth) {
+                req.SetRequestHeader("authorization", $"Bearer {Authentication.Instance.LoginToken}");
+            }
+            await req.SendWebRequest();
+            if (req.responseCode != 200) {
+                throw new Exception(req.error.ToString());
+            }
+
+            var jsonResult = JObject.Parse(req.downloadHandler.text);
+            if (jsonResult["error"] != null) {
+                throw new Exception(jsonResult["error"].ToString());
+            }
+
+            var result = JsonConvert.DeserializeObject<TResponse>(jsonResult["result"].ToString());
+            return result;
+        }
+
+        public async Task<AskForRemoteLoginResponse> AskForRemoteLogin() {
+            AskForRemoteLoginRequest request = new() { };
+            var response = await CallFunction<AskForRemoteLoginRequest, AskForRemoteLoginResponse>("askForRemoteLogin", request);
+            return response;
+        }
+
+        public async Task<GetRemoteLoginAskStatusResponse> GetRemoteLoginAskStatus(string key) {
+            GetRemoteLoginAskStatusRequest request = new() {
+                statusKey = key
+            };
+            var response = await CallFunction<GetRemoteLoginAskStatusRequest, GetRemoteLoginAskStatusResponse>("getRemoteLoginAskStatus", request);
+            return response;
+        }
+    }
+
+
+    public class FunctionCallData<T> {
+        public T data;
+    }
+    public class ArtsAndBundleStatus {
+        public enum StatusUpdate { Success, Error, None }
+
+        public Dictionary<string, ArtMeta> ArtMetas { get; } = new();
+        public Dictionary<string, Bundle> Bundles { get; } = new();
+        public StatusUpdate RecentStatusUpdate { get; set; } = StatusUpdate.None;
+    }
+
+    public class Bundle {
+        public string title;
+        public int bundleQueuePosition;
+        public string bundleStatus;
+        public Int64 lastUpdated;
+    }
+
+    public class AskForRemoteLoginRequest { }
+    public class AskForRemoteLoginResponse {
+        public string pin;
+        public string statusKey;
+        public string url;
+    }
+
+    public class GetRemoteLoginAskStatusRequest {
+        public string statusKey;
+    }
+    public class GetRemoteLoginAskStatusResponse {
+        public string status;
+        public string token;
+    }
+
+    public class UnityWebRequestAwaiter : INotifyCompletion {
+        private readonly UnityWebRequestAsyncOperation asyncOp;
+        private Action continuation;
+
+        public UnityWebRequestAwaiter(UnityWebRequestAsyncOperation asyncOp) {
+            this.asyncOp = asyncOp;
+            asyncOp.completed += OnRequestCompleted;
+        }
+
+        public bool IsCompleted { get { return asyncOp.isDone; } }
+
+        public void GetResult() { }
+
+        public void OnCompleted(Action continuation) {
+            this.continuation = continuation;
+        }
+
+        private void OnRequestCompleted(AsyncOperation obj) {
+            continuation();
+        }
+    }
+
+    public static class ExtensionMethods {
+        public static UnityWebRequestAwaiter GetAwaiter(this UnityWebRequestAsyncOperation asyncOp) {
+            return new UnityWebRequestAwaiter(asyncOp);
+        }
+    }
+
+    [Serializable]
+    public class UploadBundleResponse {
+        public string url;
+        public string artid;
+    }
+
+    public struct PluginInfo {
+        public enum FilterType { Face, Body }
+        public int version;
+        public FilterType filterType;
+        public bool resetOnRecord;
+    }
+
+    public class ReleaseInfo {
+        public Version version;
+        public string releaseNotes;
+        public class Version {
+            public int pluginAppVersion;
+            public int pluginMajorVersion;
+            public int pluginMinorVersion;
+
+            public int ToInt() {
+                return (pluginAppVersion * 100) + (pluginMajorVersion * 10) + (pluginMinorVersion);
+            }
+        }
+    }
+}

--- a/Editor/Backend.cs.meta
+++ b/Editor/Backend.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 115f888d4928046fb92f5a8358e5df58
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/DevPanel.cs
+++ b/Editor/DevPanel.cs
@@ -18,8 +18,6 @@ using Object = System.Object;
 
 namespace Filta {
     public class DevPanel : EditorWindow {
-        private string email = "";
-        private string password = "";
         private bool _stayLoggedIn;
 
         private int _selectedTab = 0;
@@ -60,7 +58,7 @@ namespace Filta {
             DevPanel window = (DevPanel)GetWindow(typeof(DevPanel), true, $"Filta: Artist Panel - {GetVersionNumber()}");
             window.ShowUtility();
         }
-        
+
         [MenuItem("Filta/Load Default Editor Layout", false, 4)]
         private static void LoadDefaultLayout() {
             string path = Path.GetFullPath($"{packagePath}/Core/FiltaLayout.wlt");
@@ -70,6 +68,8 @@ namespace Filta {
         [MenuItem("Filta/Log Out", false, 5)]
         static void LogOut() {
             Authentication.Instance.LogOut(true);
+            DevPanel window = (DevPanel)GetWindow(typeof(DevPanel), true, $"Filta: Artist Panel - {GetVersionNumber()}");
+            window.SetStatusMessage("Logged out");
             GUI.FocusControl(null);
         }
 
@@ -730,9 +730,9 @@ namespace Filta {
                 case AuthenticationState.LoggingIn:
                     SetStatusMessage("Logging in...");
                     break;
-                case AuthenticationState.LoggedOut:
-                    SetStatusMessage("Logged out");
-                    break;
+                // case AuthenticationState.LoggedOut:
+                //     SetStatusMessage("Logged out");
+                //     break;
                 case AuthenticationState.PendingAsk:
                     SetStatusMessage("Initiating remote login...");
                     break;

--- a/Editor/Global.cs
+++ b/Editor/Global.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.Networking;
+using System;
+using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+using System.IO;
+using System.Linq;
+using EvtSource;
+using Newtonsoft.Json;
+using Filta.Datatypes;
+using Newtonsoft.Json.Linq;
+using UnityEditor.PackageManager.Requests;
+using UnityEditor.SceneManagement;
+using UnityEngine.SceneManagement;
+using Object = System.Object;
+
+namespace Filta {
+    public static class Global {
+        private const string TestEnvirSetting = "Filta_TestEnvir";
+        public static bool UseTestEnvironment {
+            get { return EditorPrefs.GetBool(TestEnvirSetting, false); }
+            set { EditorPrefs.SetBool(TestEnvirSetting, value); }
+        }
+        public static string FIREBASE_APIKEY { get { return UseTestEnvironment ? "AIzaSyDaOuavnA9n0xpodrSrTO2QwoZLVhBkdVA" : "AIzaSyAiefSo-GLf2yjEwbXhr-1MxMx0A6vXHO0"; } }
+
+        public static EventHandler<StatusChangeEventArgs> StatusChange = delegate { };
+
+        public static void FireStatusChange(object sender, string message, bool isError = false) {
+            StatusChange(sender, new StatusChangeEventArgs(message, isError));
+        }
+        public static TimeSpan GetTimeSince(Int64 jsonTimestamp) {
+            DateTime origin = new(1970, 1, 1, 0, 0, 0, 0);
+            DateTime timestamp = origin.AddMilliseconds(jsonTimestamp); // convert from milliseconds to seconds
+            var result = DateTime.UtcNow - timestamp;
+            return result;
+        }
+
+    }
+
+    public class StatusChangeEventArgs : EventArgs {
+        public StatusChangeEventArgs(string message, bool isError) {
+            this.Message = message;
+            this.IsError = isError;
+        }
+        public string Message { get; private set; }
+        public bool IsError { get; private set; }
+    }
+
+
+}

--- a/Editor/Global.cs.meta
+++ b/Editor/Global.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dbdbe846144d34c109a62daff783b3fd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/omnisharp.json
+++ b/omnisharp.json
@@ -15,6 +15,8 @@
   },
   "RoslynExtensionsOptions": {
     "EnableAnalyzersSupport": true,
-    "LocationPaths": ["./NuGet/microsoft.unity.analyzers.1.10.0"]
+    "LocationPaths": [
+      "./NuGet/microsoft.unity.analyzers.1.10.0"
+    ]
   }
 }


### PR DESCRIPTION
This change makes so that users don't login with username/password. Rather, they get a code, which they can type into a page on the website, and which then logs them in, using firebase custom auth stuffs.

Authentication got a lot bigger. The code was very intertwined with devpanel UI. So I broke DevPanel out a bit. There is now 
- Globals, which is really just a place to put stuff that every other file needs
- DevPanel which is now mostly UI
- Backend which contains the code that talks to firebase and to functions
- Authentication, which contains the code that does the grungy auth stuffs.

Proof:

https://user-images.githubusercontent.com/4615465/160955518-f946364e-538f-4d53-a796-f98d7d1cbd68.mp4


