### PR TITLE
Implement naive send telemetry

### DIFF
--- a/Editor/Authentication.cs
+++ b/Editor/Authentication.cs
@@ -66,6 +66,7 @@ namespace Filta {
                 AuthState = AuthenticationState.LoggedOut;
                 PlayerPrefs.SetString(REFRESH_KEY, null);
                 PlayerPrefs.Save();
+                Backend.Instance.LogToServer(LoggingLevel.LOG, "Logout", "complete");
             }
         }
 
@@ -118,6 +119,8 @@ namespace Filta {
             AuthState = AuthenticationState.PendingAsk;
 
             try {
+                Backend.Instance.LogToServer(LoggingLevel.LOG, "Login", "start");
+
                 var response = await Backend.Instance.AskForRemoteLogin();
                 RemoteLoginPin = response.pin;
                 RemoteLoginUrl = response.url;
@@ -169,6 +172,7 @@ namespace Filta {
                                 PlayerPrefs.Save();
                             }
                             AuthState = AuthenticationState.LoggedIn;
+                            Backend.Instance.LogToServer(LoggingLevel.LOG, "Login", "success");
                             return LoginResult.Success;
                         } else {
                             Debug.LogError(refreshResponse);
@@ -190,6 +194,7 @@ namespace Filta {
             }
             // if we got this far, we failed.
             AuthState = AuthenticationState.LoggedOut;
+            Backend.Instance.LogToServer(LoggingLevel.LOG, "Login", "error");
             return LoginResult.Error;
 
         }

--- a/Editor/Backend.cs
+++ b/Editor/Backend.cs
@@ -158,6 +158,21 @@ namespace Filta {
             }
         }
 
+        public void LogToServer(LoggingLevel level, string title, string payload) {
+            var entry = new TelemetryEntry() {
+                title = title,
+                payload = payload,
+                level = level,
+                source = TelemetrySource.Plugin,
+                ts = 0
+            };
+            SendTelemetryRequest request = new() {
+                entries = new[] { entry }
+            };
+
+            _ = CallFunction<SendTelemetryRequest, SendTelemetryResponse>("sendTelemetry", request);
+        }
+
         private void ParseArtMetas(JObject json, ArtsAndBundleStatus collection) {
             var fields = json["fields"];
             if (fields == null) {
@@ -357,5 +372,37 @@ namespace Filta {
                 return (pluginAppVersion * 100) + (pluginMajorVersion * 10) + (pluginMinorVersion);
             }
         }
+    }
+
+    public enum LoggingLevel {
+        NONE = 0,
+        ERROR = 1,
+        WARN = 2,
+        LOG = 3,
+        DEBUG = 4,
+        VERBOSE = 5,
+    }
+
+    public static class TelemetrySource {
+        public const string Plugin = "plugin";
+    }
+
+    // Matches packages/shared/src/infra/telemetry.ts
+    [Serializable]
+    public class TelemetryEntry {
+        public string title;
+        public string payload;
+        public LoggingLevel level;
+        public string source; // see TelemetrySource constants
+        public long ts; // js timestamp
+    }
+
+    [Serializable]
+    public class SendTelemetryRequest {
+        public TelemetryEntry[] entries;
+    }
+
+    public class SendTelemetryResponse {
+        public string result;
     }
 }


### PR DESCRIPTION
This implementation is not as "smart" as the implementation in typescript: it will generate an I/O for every call to LogToServer, whereas the ones in app,web,assetbundler upload logs periodically. But it should be good enough for simple server logging.