### PR TITLE
Occluder play fix

### DIFF
--- a/Editor/Simulator/BodyTracking/BodySimulator.prefab
+++ b/Editor/Simulator/BodyTracking/BodySimulator.prefab
@@ -548,6 +548,7 @@ MonoBehaviour:
   mainCamera: {fileID: 6709967429197249878}
   defaultLight: {fileID: 3831128737349744715}
   _videoFeed: {fileID: 8535943671436044879}
+  simulatorData: {fileID: 11400000, guid: 14f147acd13dd475cbe49e614c55330f, type: 2}
   _visualisers: {fileID: 4643498059026719459}
   _bodyVisualiser: {fileID: 1494972964667014327}
   _bodyReference: {fileID: 1730920378736478976}

--- a/Editor/Simulator/Simulator.prefab
+++ b/Editor/Simulator/Simulator.prefab
@@ -638,6 +638,8 @@ MonoBehaviour:
   _remoteFeed: {fileID: 7382256431116267783}
   mainCamera: {fileID: 3777437209611732919}
   defaultLight: {fileID: 4417709660473707537}
+  _videoFeed: {fileID: 4417709659914063239}
+  simulatorData: {fileID: 11400000, guid: 14f147acd13dd475cbe49e614c55330f, type: 2}
   _faceMeshVisualiser: {fileID: 7865246587290439175}
   _faceSampler: {fileID: 1969032685521354159}
   _visualiserOffset: 0
@@ -649,7 +651,6 @@ MonoBehaviour:
   _facesHolder: {fileID: 0}
   _vertices: {fileID: 0}
   bounds: {fileID: 1017558197362468757, guid: fee4799afba254cce9969a3b9320a043, type: 3}
-  _videoFeed: {fileID: 4417709659914063239}
 --- !u!114 &3231588854487278633
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Editor/Simulator/SimulatorBase.cs
+++ b/Editor/Simulator/SimulatorBase.cs
@@ -63,6 +63,9 @@ public abstract class SimulatorBase : MonoBehaviour {
 
     protected const string PackagePath = "Packages/com.getfilta.artist-unityplug";
 
+    [SerializeField]
+    protected SimulatorData simulatorData;
+
     public virtual bool IsSetUpProperly() {
         return false;
     }

--- a/Editor/Simulator/SimulatorData.asset
+++ b/Editor/Simulator/SimulatorData.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3726782237fe942598ec5413a4e8384e, type: 3}
+  m_Name: SimulatorData
+  m_EditorClassIdentifier: 
+  avatarRootPaths: []

--- a/Editor/Simulator/SimulatorData.asset.meta
+++ b/Editor/Simulator/SimulatorData.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 14f147acd13dd475cbe49e614c55330f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Simulator/SimulatorData.cs
+++ b/Editor/Simulator/SimulatorData.cs
@@ -1,0 +1,6 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SimulatorData : ScriptableObject {
+    public List<string> avatarRootPaths;
+}

--- a/Editor/Simulator/SimulatorData.cs.meta
+++ b/Editor/Simulator/SimulatorData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3726782237fe942598ec5413a4e8384e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
       "pluginMajorVersion": 3,
       "pluginMinorVersion": 0
     },
-    "releaseNotes": "- feat: change object name from FaceMasks to FaceBlendshapes.\n- fix: issue of face texture not working when Variables component is on Filta object\n- feat: add onFaceAdd, onFaceRemove and onFaceUpdate nodes.\n- fix: rename OnEyeOpenValueChange nodes to OnEyeCloseValueChange\n- fix: body simulator video still showing when you switch to face only"
+    "releaseNotes": "- feat: change object name from FaceMasks to FaceBlendshapes.\n- fix: issue of face texture not working when Variables component is on Filta object\n- feat: add onFaceAdd, onFaceRemove and onFaceUpdate nodes.\n- fix: rename OnEyeOpenValueChange nodes to OnEyeCloseValueChange\n- fix: body simulator video still showing when you switch to face only\n- fix: body avatars deforming in playmode"
   }
 }


### PR DESCRIPTION
this was actually a bigger bug than i assumed. and was hard to figure out but i figured it out eventually. 

it affected not just the occluder but any body avatar which references a prefab as opposed to its mesh (for cases where users just rename their skeleton in unity and make a prefab as opposed to in blender or so). 

in playmode, we lose the ability to get a prefab instance's path. because prefabs don't exist in playmode. the solution is the store paths in a scriptable object (that we shall use to store other things later in life) and load the paths from this scriptable object. 
