### PR TITLE
feat: handle non-ar mode for proper positioning

### DIFF
--- a/Editor/DevPanel.cs
+++ b/Editor/DevPanel.cs
@@ -787,6 +787,8 @@ namespace Filta {
             _manualChatHead = EditorGUILayout.Toggle("Set filter to manual chathead", _manualChatHead);
             _manualBackground = EditorGUILayout.Toggle("Set filter to manual background", _manualBackground);
             DrawPetSimulator();
+            DrawUILine(Color.gray);
+            
             EditorGUILayout.LabelField("Artist Uid");
             _artistUid = GUILayout.TextField(_artistUid);
             EditorGUILayout.LabelField("Artist Wallet Address");
@@ -875,7 +877,17 @@ namespace Filta {
             if (GUILayout.Button("Invoke Event")) {
                 InvokeChatheadEvent();
             }
-            
+            EditorGUILayout.LabelField("AR Settings");
+            bool arMode = _faceSimulator.isAr;
+            if (arMode) {
+                if (GUILayout.Button("Switch OFF AR")) {
+                    _faceSimulator.ToggleAr();
+                }
+            } else {
+                if (GUILayout.Button("Switch ON AR")) {
+                    _faceSimulator.ToggleAr();
+                }
+            }
         }
 
         private void InvokeChatheadEvent() {
@@ -948,6 +960,9 @@ namespace Filta {
             }
             SetStatusMessage("Exporting... (1/5)");
             try {
+                if (_simulator._simulatorType == SimulatorBase.SimulatorType.Face) {
+                    _faceSimulator.ToggleAr(true);
+                }
                 if (_simulator._simulatorType == SimulatorBase.SimulatorType.Body) {
                     _bodySimulator.PauseSimulator();
                     _bodySimulator.RevertAvatarsToTPose();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.getfilta.artist-unityplug",
   "displayName": "Filta Artist Suite",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "unity": "2021.2",
   "author": "Filta",
   "description": "A suite of tools to help artists create face filters in Unity. Check www.getfilta.com for more information.",
@@ -14,7 +14,7 @@
     "version": {
       "pluginAppVersion": 2,
       "pluginMajorVersion": 6,
-      "pluginMinorVersion": 3
+      "pluginMinorVersion": 4
     },
     "releaseNotes": "- fix: minor bug fixes"
   }


### PR DESCRIPTION
### PET MAKER

this PR will enable the proper position of pets for AR mode and non-AR mode as well as preview! there's a "Switch ON/OFF AR" button in the admin tab.

### Non-AR Mode
for non-ar mode, you edit the "Twister" GameObject's Transform (position and rotation)

### AR mode
for AR mode, you edit the Offset variable in the PetHolder gameobject's component as this sets the Twister object's transform to the user's facePosition + offset.

**NOTE:** preview is best done in Playmode. also, the actual pet gameobject should be kept at position zero for the best experience.